### PR TITLE
chore: Remove deprecated Gateway EL module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.8.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.14.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.2.0</gravitee-policy-api.version>
         <gravitee-common.version>1.8.1</gravitee-common.version>
 

--- a/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyTest.java
@@ -16,15 +16,14 @@
 package io.gravitee.policy.transformheaders;
 
 import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
-import io.gravitee.gateway.api.expression.TemplateEngine;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.transformheaders.configuration.HttpHeader;
 import io.gravitee.policy.transformheaders.configuration.PolicyScope;
 import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
-//import io.gravitee.reporter.api.http.RequestMetrics;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +38,8 @@ import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+//import io.gravitee.reporter.api.http.RequestMetrics;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)


### PR DESCRIPTION
And move dependency to Gravitee EL

Closes gravitee-io/issues#1987