### PR TITLE
feat: Add support for request / response's payload to define HTTP hea…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,11 +9,15 @@ endif::[]
 
 == Phase
 
-[cols="2*", options="header"]
+[cols="4*", options="header"]
 |===
 ^|onRequest
 ^|onResponse
+^|onRequestContent
+^|onResponseContent
 
+^.^| X
+^.^| X
 ^.^| X
 ^.^| X
 
@@ -47,5 +51,20 @@ You can override the HTTP headers by:
         "Content-Length"
     ],
     "scope": "REQUEST"
+}
+----
+
+Add a header from the request's payload:
+
+[source, json]
+----
+"transform-headers": {
+    "addHeaders": [
+        {
+            "name": "X-Product-Id",
+            "value": "{#jsonPath(#request.content, '$.product.id')}"
+        }
+    ]
+    "scope": "REQUEST_CONTENT"
 }
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.24.0</gravitee-common.version>
+        <gravitee-apim-gateway-buffer.version>3.16.1</gravitee-apim-gateway-buffer.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -93,6 +94,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${gravitee-apim-gateway-buffer.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/transformheaders/configuration/PolicyScope.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/configuration/PolicyScope.java
@@ -22,4 +22,6 @@ package io.gravitee.policy.transformheaders.configuration;
 public enum PolicyScope {
     REQUEST,
     RESPONSE,
+    REQUEST_CONTENT,
+    RESPONSE_CONTENT,
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -4,10 +4,10 @@
   "properties" : {
     "scope" : {
       "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
+      "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>response</strong> (HEAD) phase, <strong>request_content</strong> (includes payload) phase, <strong>response content</strong> (includes payload) phase.",
       "type" : "string",
       "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE" ],
+      "enum" : [ "REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT"],
       "deprecated": "true"
     },
     "removeHeaders" : {


### PR DESCRIPTION
…ders values

Closes gravitee-io/issues#7333

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.0-SNAPSHOT.issues-7333-header-payload`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/1.10.0-SNAPSHOT.issues-7333-header-payload/gravitee-policy-transformheaders-1.10.0-SNAPSHOT.issues-7333-header-payload.zip)
  <!-- Version placeholder end -->
