### PR TITLE
Clean and validate json schema for v4

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,65 +1,65 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:transformheaders:configuration:TransformHeadersPolicyConfiguration",
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> (HEAD) phase, <strong>response</strong> (HEAD) phase, <strong>request_content</strong> (includes payload) phase, <strong>response content</strong> (includes payload) phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT"],
-      "deprecated": "true"
-    },
-    "removeHeaders" : {
-      "type" : "array",
-      "title": "Remove headers",
-      "items" : {
-        "type" : ["string", "null"],
-        "description": "Name of the header",
-        "title": "Header"
-      }
-    },
-    "whitelistHeaders": {
-      "type": "array",
-      "title": "Headers to keep",
-      "description": "Works like a whitelist. All other headers will be removed.",
-      "items": {
-        "type": ["string", "null"],
-        "description": "Name of the header",
-        "title": "Header"
-      }
-    },
-    "addHeaders" : {
-      "type" : "array",
-      "title": "Add / update headers",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:io:gravitee:policy:transformheaders:configuration:HttpHeader",
-        "title": "Header",
-        "properties" : {
-          "name" : {
-            "title": "Name",
-            "description": "Name of the header",
-            "type" : "string",
-            "pattern" : "^\\S*$",
-            "validationMessage": {
-              "202": "Header name must not contain spaces."
-            }
-          },
-          "value" : {
-            "title": "Value",
-            "description": "Value of the header",
-            "type" : "string",
-            "x-schema-form": {
-              "expression-language": true
-            }
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Select phase to execute the policy.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE", "REQUEST_CONTENT", "RESPONSE_CONTENT"],
+            "deprecated": "true"
         },
-        "required": [
-          "name",
-          "value"
-        ]
-      }
+        "removeHeaders": {
+            "type": "array",
+            "title": "Remove headers",
+            "items": {
+                "type": ["string", "null"],
+                "description": "Name of the header",
+                "title": "Header"
+            }
+        },
+        "whitelistHeaders": {
+            "type": "array",
+            "title": "Headers to keep",
+            "description": "Works like a whitelist. All other headers will be removed.",
+            "items": {
+                "type": ["string", "null"],
+                "description": "Name of the header",
+                "title": "Header"
+            }
+        },
+        "addHeaders": {
+            "type": "array",
+            "title": "Add / update headers",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the header",
+                        "type": "string",
+                        "pattern": "^\\S*$",
+                        "validationMessage": {
+                            "202": "Header name must not contain spaces."
+                        }
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the header",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
+            },
+            "gioConfig": {
+                "uiType": "gio-headers-array"
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

**Description**

clean and validate json schema for v4

Tested with :
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/2.1.0-json-schema-SNAPSHOT/gravitee-policy-transformheaders-2.1.0-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
