### PR TITLE
fix: make acceptlist case insensitive

### DIFF
--- a/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
@@ -194,7 +194,7 @@ public class TransformHeadersPolicy {
             httpHeaders
                 .names()
                 .forEach(headerName -> {
-                    if (!transformHeadersPolicyConfiguration.getWhitelistHeaders().contains(headerName)) {
+                    if (transformHeadersPolicyConfiguration.getWhitelistHeaders().stream().noneMatch(headerName::equalsIgnoreCase)) {
                         headersToRemove.add(headerName);
                     }
                 });

--- a/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyTest.java
@@ -295,9 +295,9 @@ public class TransformHeadersPolicyTest {
     @Test
     public void testOnResponse_removeHeaderAndWhiteList() {
         // Prepare
-        responseHtpHeaders.set("X-Gravitee-ToRemove", "Initial");
-        responseHtpHeaders.set("X-Gravitee-White", "Initial");
-        responseHtpHeaders.set("X-Gravitee-Black", "Initial");
+        responseHtpHeaders.set("x-gravitee-toremove", "Initial");
+        responseHtpHeaders.set("x-gravitee-white", "Initial");
+        responseHtpHeaders.set("x-gravitee-black", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
         when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(null);
         when(transformHeadersPolicyConfiguration.getRemoveHeaders()).thenReturn(Collections.singletonList("X-Gravitee-ToRemove"));
@@ -344,8 +344,8 @@ public class TransformHeadersPolicyTest {
     @Test
     public void testOnResponse_whitelistHeader() {
         // Prepare
-        responseHtpHeaders.set("X-Walter", "Initial");
-        responseHtpHeaders.set("X-White", "Initial");
+        responseHtpHeaders.set("x-walter", "Initial");
+        responseHtpHeaders.set("x-white", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
         when(transformHeadersPolicyConfiguration.getWhitelistHeaders()).thenReturn(Collections.singletonList("X-White"));
 
@@ -361,8 +361,8 @@ public class TransformHeadersPolicyTest {
     @Test
     public void testOnRequest_whitelistHeader() {
         // Prepare
-        requestHttpHeaders.set("X-Walter", "Initial");
-        requestHttpHeaders.set("X-White", "Initial");
+        requestHttpHeaders.set("x-walter", "Initial");
+        requestHttpHeaders.set("x-white", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.REQUEST);
         when(transformHeadersPolicyConfiguration.getWhitelistHeaders()).thenReturn(Collections.singletonList("X-White"));
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3283

**Description**

make acceptlist case insensitive.

Another PR is coming for master branch
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.1-apim-3283-fix-case-sensitive-rules-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/1.10.1-apim-3283-fix-case-sensitive-rules-SNAPSHOT/gravitee-policy-transformheaders-1.10.1-apim-3283-fix-case-sensitive-rules-SNAPSHOT.zip)
  <!-- Version placeholder end -->
