### PR TITLE
fix: make acceptlist case insensitive

### DIFF
--- a/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
@@ -110,7 +110,7 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
                         httpHeaders
                             .names()
                             .forEach(headerName -> {
-                                if (!configuration.getWhitelistHeaders().contains(headerName)) {
+                                if (configuration.getWhitelistHeaders().stream().noneMatch(headerName::equalsIgnoreCase)) {
                                     headersToRemove.add(headerName);
                                 }
                             });

--- a/src/main/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3.java
@@ -186,7 +186,7 @@ public class TransformHeadersPolicyV3 {
             httpHeaders
                 .names()
                 .forEach(headerName -> {
-                    if (!configuration.getWhitelistHeaders().contains(headerName)) {
+                    if (configuration.getWhitelistHeaders().stream().noneMatch(headerName::equalsIgnoreCase)) {
                         headersToRemove.add(headerName);
                     }
                 });

--- a/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyV4IntegrationTest.java
@@ -99,11 +99,11 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
             get("/endpoint")
                 .willReturn(
                     ok()
-                        .withHeader("toUpdateKeyResponse", "responseToUpdate")
-                        .withHeader("toRemoveKeyResponse", "willBeRemoved")
-                        .withHeader("whitelistedKeyResponse", "whitelisted")
-                        .withHeader("notInWhitelistKeyResponse1", "excluded")
-                        .withHeader("notInWhitelistKeyResponse2", "excluded")
+                        .withHeader("toupdatekeyresponse", "responseToUpdate")
+                        .withHeader("toremovekeyresponse", "willBeRemoved")
+                        .withHeader("whitelistedkeyresponse", "whitelisted")
+                        .withHeader("notinwhitelistkeyresponse1", "excluded")
+                        .withHeader("notinwhitelistkeyresponse2", "excluded")
                 )
         );
 
@@ -111,11 +111,11 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
             .request(HttpMethod.GET, "/test")
             .flatMap(request ->
                 request
-                    .putHeader("toUpdateKey", "firstValue")
-                    .putHeader("toRemoveKey", "willBeRemoved")
-                    .putHeader("whitelistedKey", "whitelisted")
-                    .putHeader("notInWhitelistKey1", "excluded")
-                    .putHeader("notInWhitelistKey2", "excluded")
+                    .putHeader("toupdatekey", "firstValue")
+                    .putHeader("toremovekey", "willBeRemoved")
+                    .putHeader("whitelistedkey", "whitelisted")
+                    .putHeader("notinwhitelistkey1", "excluded")
+                    .putHeader("notinwhitelistkey2", "excluded")
                     .rxSend()
             )
             .test();
@@ -137,12 +137,12 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
 
         wiremock.verify(
             getRequestedFor(urlPathEqualTo("/endpoint"))
-                .withHeader("headerKey", equalTo("headerValue"))
-                .withHeader("toUpdateKey", equalTo("updatedValue"))
-                .withHeader("whitelistedKey", equalTo("whitelisted"))
-                .withoutHeader("toRemoveKey")
-                .withoutHeader("notInWhitelistKey1")
-                .withoutHeader("notInWhitelistKey2")
+                .withHeader("headerkey", equalTo("headerValue"))
+                .withHeader("toupdatekey", equalTo("updatedValue"))
+                .withHeader("whitelistedkey", equalTo("whitelisted"))
+                .withoutHeader("toremovekey")
+                .withoutHeader("notinwhitelistkey1")
+                .withoutHeader("notinwhitelistkey2")
         );
     }
 
@@ -153,11 +153,11 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
             .rxRequest(POST, "/test")
             .flatMap(request ->
                 request
-                    .putHeader("toUpdateKey", "firstValue")
-                    .putHeader("toRemoveKey", "willBeRemoved")
-                    .putHeader("whitelistedKey", "whitelisted")
-                    .putHeader("notInWhitelistKey1", "excluded")
-                    .putHeader("notInWhitelistKey2", "excluded")
+                    .putHeader("toupdatekey", "firstValue")
+                    .putHeader("toremovekey", "willBeRemoved")
+                    .putHeader("whitelistedkey", "whitelisted")
+                    .putHeader("notinwhitelistkey1", "excluded")
+                    .putHeader("notinwhitelistkey2", "excluded")
                     .rxSend("message")
             )
             .flatMap(response -> {

--- a/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3IntegrationTest.java
@@ -48,11 +48,11 @@ class TransformHeadersPolicyV3IntegrationTest extends AbstractPolicyTest<Transfo
             get("/endpoint")
                 .willReturn(
                     ok()
-                        .withHeader("toUpdateKeyResponse", "responseToUpdate")
-                        .withHeader("toRemoveKeyResponse", "willBeRemoved")
-                        .withHeader("whitelistedKeyResponse", "whitelisted")
-                        .withHeader("notInWhitelistKeyResponse1", "excluded")
-                        .withHeader("notInWhitelistKeyResponse2", "excluded")
+                        .withHeader("toupdatekeyresponse", "responseToUpdate")
+                        .withHeader("toremovekeyresponse", "willBeRemoved")
+                        .withHeader("whitelistedkeyresponse", "whitelisted")
+                        .withHeader("notinwhitelistkeyresponse1", "excluded")
+                        .withHeader("notinwhitelistkeyresponse2", "excluded")
                 )
         );
 
@@ -60,11 +60,11 @@ class TransformHeadersPolicyV3IntegrationTest extends AbstractPolicyTest<Transfo
             .request(HttpMethod.GET, "/test")
             .flatMap(request ->
                 request
-                    .putHeader("toUpdateKey", "firstValue")
-                    .putHeader("toRemoveKey", "willBeRemoved")
-                    .putHeader("whitelistedKey", "whitelisted")
-                    .putHeader("notInWhitelistKey1", "excluded")
-                    .putHeader("notInWhitelistKey2", "excluded")
+                    .putHeader("toupdatekey", "firstValue")
+                    .putHeader("toremovekey", "willBeRemoved")
+                    .putHeader("whitelistedkey", "whitelisted")
+                    .putHeader("notinwhitelistkey1", "excluded")
+                    .putHeader("notinwhitelistkey2", "excluded")
                     .rxSend()
             )
             .test();
@@ -86,12 +86,12 @@ class TransformHeadersPolicyV3IntegrationTest extends AbstractPolicyTest<Transfo
 
         wiremock.verify(
             getRequestedFor(urlPathEqualTo("/endpoint"))
-                .withHeader("headerKey", equalTo("headerValue"))
-                .withHeader("toUpdateKey", equalTo("updatedValue"))
-                .withHeader("whitelistedKey", equalTo("whitelisted"))
-                .withoutHeader("toRemoveKey")
-                .withoutHeader("notInWhitelistKey1")
-                .withoutHeader("notInWhitelistKey2")
+                .withHeader("headerkey", equalTo("headerValue"))
+                .withHeader("toupdatekey", equalTo("updatedValue"))
+                .withHeader("whitelistedkey", equalTo("whitelisted"))
+                .withoutHeader("toremovekey")
+                .withoutHeader("notinwhitelistkey1")
+                .withoutHeader("notinwhitelistkey2")
         );
     }
 }

--- a/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3Test.java
@@ -301,9 +301,9 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnResponse_removeHeaderAndWhiteList() {
         // Prepare
-        responseHttpHeaders.set("X-Gravitee-ToRemove", "Initial");
-        responseHttpHeaders.set("X-Gravitee-White", "Initial");
-        responseHttpHeaders.set("X-Gravitee-Black", "Initial");
+        responseHttpHeaders.set("x-gravitee-toremove", "Initial");
+        responseHttpHeaders.set("x-gravitee-white", "Initial");
+        responseHttpHeaders.set("x-gravitee-black", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
         when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(null);
         when(transformHeadersPolicyConfiguration.getRemoveHeaders()).thenReturn(Collections.singletonList("X-Gravitee-ToRemove"));
@@ -350,8 +350,8 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnResponse_whitelistHeader() {
         // Prepare
-        responseHttpHeaders.set("X-Walter", "Initial");
-        responseHttpHeaders.set("X-White", "Initial");
+        responseHttpHeaders.set("x-walter", "Initial");
+        responseHttpHeaders.set("x-white", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
         when(transformHeadersPolicyConfiguration.getWhitelistHeaders()).thenReturn(Collections.singletonList("X-White"));
 
@@ -367,8 +367,8 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnRequest_whitelistHeader() {
         // Prepare
-        requestHttpHeaders.set("X-Walter", "Initial");
-        requestHttpHeaders.set("X-White", "Initial");
+        requestHttpHeaders.set("x-walter", "Initial");
+        requestHttpHeaders.set("x-white", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.REQUEST);
         when(transformHeadersPolicyConfiguration.getWhitelistHeaders()).thenReturn(Collections.singletonList("X-White"));
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3283

**Description**

Make acceptlist case insensitive
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.2-apim-3283-fix-case-sensitive-rules-4-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/3.0.2-apim-3283-fix-case-sensitive-rules-4-x-SNAPSHOT/gravitee-policy-transformheaders-3.0.2-apim-3283-fix-case-sensitive-rules-4-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
