### PR TITLE
feat: add append header support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.13.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -53,6 +53,12 @@ You can override the HTTP headers by:
             "value": "{#request.id}"
         }
     ],
+    "appendHeaders": [
+        {
+            "name": "Accept-Encoding",
+            "value": "gzip"
+        }
+    ],
     "removeHeaders": [
         "X-Gravitee-TransactionId"
     ],
@@ -64,7 +70,7 @@ You can override the HTTP headers by:
 }
 ----
 
-Add a header from the request's payload:
+Set / replace a header from the request's payload:
 
 [source, json]
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -30,20 +30,15 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.2.4</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-expression-language.version>3.0.0</gravitee-expression-language.version>
-        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-sse.version>4.0.0</gravitee-sse.version>
-        <gravitee-http-post.version>1.0.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>1.0.1</gravitee-reactor-message.version>
+        <gravitee-apim.version>4.6.0</gravitee-apim.version>
+
+        <gravitee-sse.version>5.0.0</gravitee-sse.version>
+        <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
+        <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
 
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
@@ -54,38 +49,12 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.el</groupId>
-                <artifactId>gravitee-expression-language</artifactId>
-                <version>${gravitee-expression-language.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.common</groupId>
-                <artifactId>gravitee-common</artifactId>
-                <version>${gravitee-common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node</artifactId>
-                <version>${gravitee-node.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/io/gravitee/policy/transformheaders/configuration/TransformHeadersPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/configuration/TransformHeadersPolicyConfiguration.java
@@ -17,12 +17,16 @@ package io.gravitee.policy.transformheaders.configuration;
 
 import io.gravitee.policy.api.PolicyConfiguration;
 import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class TransformHeadersPolicyConfiguration implements PolicyConfiguration {
 
     private PolicyScope scope = PolicyScope.REQUEST;
@@ -31,37 +35,7 @@ public class TransformHeadersPolicyConfiguration implements PolicyConfiguration 
 
     private List<HttpHeader> addHeaders = null;
 
+    private List<HttpHeader> appendHeaders = null;
+
     private List<String> whitelistHeaders = null;
-
-    public PolicyScope getScope() {
-        return scope;
-    }
-
-    public void setScope(PolicyScope scope) {
-        this.scope = scope;
-    }
-
-    public List<String> getRemoveHeaders() {
-        return removeHeaders;
-    }
-
-    public void setRemoveHeaders(List<String> removeHeaders) {
-        this.removeHeaders = removeHeaders;
-    }
-
-    public List<HttpHeader> getAddHeaders() {
-        return addHeaders;
-    }
-
-    public void setAddHeaders(List<HttpHeader> addHeaders) {
-        this.addHeaders = addHeaders;
-    }
-
-    public List<String> getWhitelistHeaders() {
-        return whitelistHeaders;
-    }
-
-    public void setWhitelistHeaders(List<String> whitelistHeaders) {
-        this.whitelistHeaders = whitelistHeaders;
-    }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -32,7 +32,40 @@
         },
         "addHeaders": {
             "type": "array",
-            "title": "Add / update headers",
+            "title": "Set / Replace headers",
+            "description": "Values defined here will be replaced if a header with the same name is already defined in the request.",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the header",
+                        "type": "string",
+                        "pattern": "^\\S*$",
+                        "validationMessage": {
+                            "202": "Header name must not contain spaces."
+                        }
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the header",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
+            },
+            "gioConfig": {
+                "uiType": "gio-headers-array"
+            }
+        },
+        "appendHeaders": {
+            "type": "array",
+            "title": "Append headers",
+            "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name",
             "items": {
                 "type": "object",
                 "title": "Header",

--- a/src/test/resources/apis/add-update-whitelist-remove-append-headers.json
+++ b/src/test/resources/apis/add-update-whitelist-remove-append-headers.json
@@ -41,8 +41,18 @@
                                 "value": "updatedValue"
                             }
                         ],
-                        "whitelistHeaders": ["headerKey", "toUpdateKey", "whitelistedKey", "toRemoveKey"],
+                        "whitelistHeaders": ["headerKey", "toUpdateKey", "whitelistedKey", "toRemoveKey", "headerKeyAppend"],
                         "removeHeaders": ["toRemoveKey"],
+                        "appendHeaders": [
+                            {
+                                "name": "headerKeyAppend",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKeyAppend",
+                                "value": "headerValue2"
+                            }
+                        ],
                         "scope": "REQUEST"
                     }
                 }
@@ -64,8 +74,24 @@
                                 "value": "updatedValue"
                             }
                         ],
-                        "whitelistHeaders": ["headerKeyResponse", "toUpdateKeyResponse", "whitelistedKeyResponse", "toRemoveKeyResponse"],
+                        "whitelistHeaders": [
+                            "headerKeyResponse",
+                            "toUpdateKeyResponse",
+                            "whitelistedKeyResponse",
+                            "toRemoveKeyResponse",
+                            "headerKeyResponseAppend"
+                        ],
                         "removeHeaders": ["toRemoveKeyResponse"],
+                        "appendHeaders": [
+                            {
+                                "name": "headerKeyResponseAppend",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKeyResponseAppend",
+                                "value": "headerValue2"
+                            }
+                        ],
                         "scope": "RESPONSE"
                     }
                 }

--- a/src/test/resources/apis/append-headers-v4-message-publish.json
+++ b/src/test/resources/apis/append-headers-v4-message-publish.json
@@ -1,0 +1,73 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "message",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-post",
+                    "configuration": {
+                        "requestHeadersToMessage": true
+                    }
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "mock",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "mock",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "messageInterval": 1000,
+                        "messageContent": "{ \"message\": \"hello\" }"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [],
+            "response": [],
+            "subscribe": [],
+            "publish": [
+                {
+                    "name": "Transform Headers",
+                    "description": "Transform Headers on response",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {
+                        "appendHeaders": [
+                            {
+                                "name": "headerKey",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKey",
+                                "value": "headerValue2"
+                            }
+                        ],
+                        "scope": "REQUEST"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/append-headers-v4-message-subscribe.json
+++ b/src/test/resources/apis/append-headers-v4-message-subscribe.json
@@ -1,0 +1,81 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "message",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "sse",
+                    "configuration": {
+                        "headersAsComment": true
+                    }
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "mock",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "mock",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "messageCount": 1,
+                        "messageContent": "{ \"message\": \"hello\" }",
+                        "headers": [
+                            {
+                                "name": "headerKeyResponse",
+                                "value": "headerValue0"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [],
+            "response": [],
+            "publish": [],
+            "subscribe": [
+                {
+                    "name": "Transform Headers",
+                    "description": "Transform Headers on request",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {
+                        "appendHeaders": [
+                            {
+                                "name": "headerKeyResponse",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKeyResponse",
+                                "value": "headerValue2"
+                            }
+                        ],
+                        "whitelistHeaders": ["headerKeyResponse", "toUpdateKeyResponse", "whitelistedKeyResponse", "toRemoveKeyResponse"],
+                        "removeHeaders": ["toRemoveKeyResponse"],
+                        "scope": "RESPONSE"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/apis/append-headers-v4-proxy.json
+++ b/src/test/resources/apis/append-headers-v4-proxy.json
@@ -1,0 +1,87 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "apiVersion": "1.0",
+    "definitionVersion": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "http://localhost:8080/endpoint"
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "request": [
+                {
+                    "name": "Transform Headers",
+                    "description": "Transform Headers on request",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {
+                        "appendHeaders": [
+                            {
+                                "name": "headerKey",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKey",
+                                "value": "headerValue2"
+                            }
+                        ],
+                        "scope": "REQUEST"
+                    }
+                }
+            ],
+            "response": [
+                {
+                    "name": "Transform Headers",
+                    "description": "Transform Headers on response",
+                    "enabled": true,
+                    "policy": "transform-headers",
+                    "configuration": {
+                        "appendHeaders": [
+                            {
+                                "name": "headerKeyResponse",
+                                "value": "headerValue1"
+                            },
+                            {
+                                "name": "headerKeyResponse",
+                                "value": "headerValue2"
+                            }
+                        ],
+                        "scope": "RESPONSE"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-1075

This is required to pass kubernetes.io gateway-api conformance tests
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-gko-1075-append-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/3.1.0-gko-1075-append-headers-SNAPSHOT/gravitee-policy-transformheaders-3.1.0-gko-1075-append-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
