### PR TITLE
Transform Kafka headers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,13 +19,17 @@ endif::[]
 
 == Phase
 
-[cols="4*", options="header"]
+[cols="6*", options="header"]
 |===
 ^|onRequest
 ^|onResponse
 ^|onRequestContent
 ^|onResponseContent
+^|onMessageRequest
+^|onMessageResponse
 
+^.^| X
+^.^| X
 ^.^| X
 ^.^| X
 ^.^| X
@@ -41,6 +45,8 @@ You can override the HTTP headers by:
 * Adding to or updating the list of headers
 * Removing headers individually
 * Defining a whitelist
+
+Updating a list of values for a given header is not supported for Native APIs.
 
 == Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,20 +30,18 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.2.4</version>
+        <version>22.2.5</version>
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.0</gravitee-apim.version>
-
+        <gravitee-apim.version>4.6.8</gravitee-apim.version>
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
         <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>5.0.1</gravitee-reactor-message.version>
 
-        <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
-        <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
+        <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
+        <maven-plugin-properties.version>1.2.0</maven-plugin-properties.version>
 
-        <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
@@ -66,24 +64,16 @@
             <artifactId>gravitee-gateway-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>io.gravitee.el</groupId>
-            <artifactId>gravitee-expression-language</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <scope>provided</scope>
         </dependency>
-
         <dependency>
-            <groupId>io.gravitee.common</groupId>
-            <artifactId>gravitee-common</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>

--- a/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
@@ -16,23 +16,33 @@
 package io.gravitee.policy.transformheaders;
 
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpMessageExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaExecutionContext;
+import io.gravitee.gateway.reactive.api.context.kafka.KafkaMessageExecutionContext;
 import io.gravitee.gateway.reactive.api.message.Message;
-import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.message.kafka.KafkaMessage;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
+import io.gravitee.gateway.reactive.api.policy.kafka.KafkaPolicy;
+import io.gravitee.policy.transformheaders.configuration.HttpHeader;
 import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
 import io.gravitee.policy.transformheaders.v3.TransformHeadersPolicyV3;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.function.BiFunction;
+import org.apache.kafka.common.protocol.Errors;
 
 /**
  * @author Guillaume Lamirand (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements Policy {
+public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements HttpPolicy, KafkaPolicy {
 
     private static final String TRANSFORM_HEADERS_FAILURE = "TRANSFORM_HEADERS_FAILURE";
 
@@ -46,16 +56,16 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
     }
 
     @Override
-    public Completable onRequest(HttpExecutionContext ctx) {
+    public Completable onRequest(HttpPlainExecutionContext ctx) {
         return Completable.defer(() -> transform(ctx, ctx.request().headers()));
     }
 
     @Override
-    public Completable onResponse(HttpExecutionContext ctx) {
+    public Completable onResponse(HttpPlainExecutionContext ctx) {
         return Completable.defer(() -> transform(ctx, ctx.response().headers()));
     }
 
-    private Completable transform(final HttpExecutionContext ctx, final HttpHeaders httpHeaders) {
+    private Completable transform(final HttpPlainExecutionContext ctx, final HttpHeaders httpHeaders) {
         return transformHeaders(ctx.getTemplateEngine(), httpHeaders)
             .onErrorResumeWith(
                 ctx.interruptWith(
@@ -65,16 +75,16 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
     }
 
     @Override
-    public Completable onMessageRequest(MessageExecutionContext ctx) {
+    public Completable onMessageRequest(HttpMessageExecutionContext ctx) {
         return ctx.request().onMessage(message -> transformMessageHeaders(ctx, message));
     }
 
     @Override
-    public Completable onMessageResponse(MessageExecutionContext ctx) {
+    public Completable onMessageResponse(HttpMessageExecutionContext ctx) {
         return ctx.response().onMessage(message -> transformMessageHeaders(ctx, message));
     }
 
-    private Maybe<Message> transformMessageHeaders(final MessageExecutionContext ctx, final Message message) {
+    private Maybe<Message> transformMessageHeaders(final HttpMessageExecutionContext ctx, final Message message) {
         return transformHeaders(ctx.getTemplateEngine(message), message.headers())
             .andThen(Maybe.just(message))
             .onErrorResumeWith(
@@ -85,33 +95,68 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
     }
 
     private Completable transformHeaders(final TemplateEngine templateEngine, final HttpHeaders httpHeaders) {
-        return setHeaders(templateEngine, httpHeaders)
+        return addHeaders(templateEngine, httpHeaders)
             .andThen(appendHeaders(templateEngine, httpHeaders))
             .andThen(Completable.fromRunnable(() -> removeHeaders(httpHeaders)));
     }
 
-    private Completable setHeaders(final TemplateEngine templateEngine, final HttpHeaders httpHeaders) {
-        return Maybe
-            .fromCallable(configuration::getAddHeaders)
-            .flatMapPublisher(Flowable::fromIterable)
-            .filter(httpHeader -> httpHeader.getName() != null && !httpHeader.getName().trim().isEmpty() && httpHeader.getValue() != null)
-            .flatMapCompletable(httpHeader ->
-                templateEngine
-                    .eval(httpHeader.getValue(), String.class)
-                    .doOnSuccess(newValue -> httpHeaders.set(httpHeader.getName(), newValue))
-                    .ignoreElement()
-            );
+    private Completable addHeaders(final TemplateEngine templateEngine, final HttpHeaders httpHeaders) {
+        return updateHeaders(
+            configuration::getAddHeaders,
+            templateEngine,
+            (key, value) -> Optional.ofNullable(httpHeaders).map(h -> h.set(key, value)).orElse(null)
+        );
     }
 
     private Completable appendHeaders(final TemplateEngine templateEngine, final HttpHeaders httpHeaders) {
+        return updateHeaders(
+            configuration::getAppendHeaders,
+            templateEngine,
+            (key, value) -> Optional.ofNullable(httpHeaders).map(h -> h.add(key, value)).orElse(null)
+        );
+    }
+
+    @Override
+    public Completable onMessageRequest(KafkaMessageExecutionContext ctx) {
+        return ctx.request().onMessage(message -> transformKafkaMessageHeaders(ctx.executionContext(), message));
+    }
+
+    @Override
+    public Completable onMessageResponse(KafkaMessageExecutionContext ctx) {
+        return ctx.response().onMessage(message -> transformKafkaMessageHeaders(ctx.executionContext(), message));
+    }
+
+    private Maybe<KafkaMessage> transformKafkaMessageHeaders(KafkaExecutionContext ctx, KafkaMessage kafkaMessage) {
+        return transformHeaders(ctx.getTemplateEngine(), kafkaMessage)
+            .onErrorResumeWith(ctx.interruptWith(Errors.INVALID_RECORD))
+            .andThen(Maybe.just(kafkaMessage));
+    }
+
+    private Completable transformHeaders(final TemplateEngine templateEngine, final KafkaMessage message) {
+        return addHeaders(templateEngine, message).andThen(Completable.fromRunnable(() -> removeHeaders(message)));
+    }
+
+    private Completable addHeaders(final TemplateEngine templateEngine, final KafkaMessage message) {
+        return updateHeaders(
+            configuration::getAddHeaders,
+            templateEngine,
+            (key, value) -> message.putRecordHeader(key, Buffer.buffer(value))
+        );
+    }
+
+    private Completable updateHeaders(
+        Callable<List<HttpHeader>> configurationHeaders,
+        final TemplateEngine templateEngine,
+        BiFunction<String, String, ?> updateHeaders
+    ) {
         return Maybe
-            .fromCallable(configuration::getAppendHeaders)
+            .fromCallable(configurationHeaders)
             .flatMapPublisher(Flowable::fromIterable)
             .filter(httpHeader -> httpHeader.getName() != null && !httpHeader.getName().trim().isEmpty() && httpHeader.getValue() != null)
             .flatMapCompletable(httpHeader ->
                 templateEngine
                     .eval(httpHeader.getValue(), String.class)
-                    .doOnSuccess(newValue -> httpHeaders.add(httpHeader.getName(), newValue))
+                    .doOnSuccess(newValue -> updateHeaders.apply(httpHeader.getName(), newValue))
                     .ignoreElement()
             );
     }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,5 +6,9 @@ class=io.gravitee.policy.transformheaders.TransformHeadersPolicy
 type=policy
 category=transformation
 icon=transform-headers.svg
-proxy=REQUEST,RESPONSE 
+documentation=README.adoc
+schema=schema-form.json
+proxy=REQUEST,RESPONSE
 message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
+
+native_kafka=PUBLISH,SUBSCRIBE

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -65,7 +65,7 @@
         "appendHeaders": {
             "type": "array",
             "title": "Append headers",
-            "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name",
+            "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name.",
             "items": {
                 "type": "object",
                 "title": "Header",
@@ -91,7 +91,12 @@
                 "required": ["name", "value"]
             },
             "gioConfig": {
-                "uiType": "gio-headers-array"
+                "uiType": "gio-headers-array",
+                "displayIf": {
+                    "$eq": {
+                        "context.apiType": ["MESSAGE", "PROXY"]
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8981

**Description**

- Update dependencies
- Handle Kafka messages

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.0-apim-8981-transform-kafka-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/3.2.0-apim-8981-transform-kafka-headers-SNAPSHOT/gravitee-policy-transformheaders-3.2.0-apim-8981-transform-kafka-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
