### PR TITLE
fix: revert BC commit -- "feat: handle KafkaPolicy on message request…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,17 +19,13 @@ endif::[]
 
 == Phase
 
-[cols="6*", options="header"]
+[cols="4*", options="header"]
 |===
 ^|onRequest
 ^|onResponse
 ^|onRequestContent
 ^|onResponseContent
-^|onMessageRequest
-^|onMessageResponse
 
-^.^| X
-^.^| X
 ^.^| X
 ^.^| X
 ^.^| X
@@ -45,8 +41,6 @@ You can override the HTTP headers by:
 * Adding to or updating the list of headers
 * Removing headers individually
 * Defining a whitelist
-
-Updating a list of values for a given header is not supported for Native APIs.
 
 == Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,18 +30,20 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.2.5</version>
+        <version>22.2.4</version>
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.8</gravitee-apim.version>
+        <gravitee-apim.version>4.6.0</gravitee-apim.version>
+
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
         <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>5.0.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
 
-        <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
-        <maven-plugin-properties.version>1.2.0</maven-plugin-properties.version>
+        <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
+        <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
+        <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
@@ -64,16 +66,24 @@
             <artifactId>gravitee-gateway-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>

--- a/src/main/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3.java
@@ -27,7 +27,6 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
-import io.gravitee.gateway.reactive.api.message.kafka.KafkaMessage;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.api.annotations.OnRequestContent;
@@ -230,30 +229,6 @@ public class TransformHeadersPolicyV3 {
         headersToRemove.forEach(headerName -> {
             if (headerName != null && !headerName.trim().isEmpty()) {
                 httpHeaders.remove(headerName);
-            }
-        });
-    }
-
-    protected void removeHeaders(final KafkaMessage kafkaMessage) {
-        List<String> headersToRemove = configuration.getRemoveHeaders() == null
-            ? new ArrayList<>()
-            : new ArrayList<>(configuration.getRemoveHeaders());
-
-        if (configuration.getWhitelistHeaders() != null && !configuration.getWhitelistHeaders().isEmpty()) {
-            kafkaMessage
-                .recordHeaders()
-                .keySet()
-                .forEach(headerName -> {
-                    if (configuration.getWhitelistHeaders().stream().noneMatch(headerName::equalsIgnoreCase)) {
-                        headersToRemove.add(headerName);
-                    }
-                });
-        }
-
-        // Remove request headers
-        headersToRemove.forEach(headerName -> {
-            if (headerName != null && !headerName.trim().isEmpty()) {
-                kafkaMessage.removeRecordHeader(headerName);
             }
         });
     }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,9 +6,5 @@ class=io.gravitee.policy.transformheaders.TransformHeadersPolicy
 type=policy
 category=transformation
 icon=transform-headers.svg
-documentation=README.adoc
-schema=schema-form.json
-proxy=REQUEST,RESPONSE
+proxy=REQUEST,RESPONSE 
 message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
-
-native_kafka=PUBLISH,SUBSCRIBE

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -65,7 +65,7 @@
         "appendHeaders": {
             "type": "array",
             "title": "Append headers",
-            "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name.",
+            "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name",
             "items": {
                 "type": "object",
                 "title": "Header",
@@ -91,12 +91,7 @@
                 "required": ["name", "value"]
             },
             "gioConfig": {
-                "uiType": "gio-headers-array",
-                "displayIf": {
-                    "$eq": {
-                        "context.apiType": ["MESSAGE", "PROXY"]
-                    }
-                }
+                "uiType": "gio-headers-array"
             }
         }
     }


### PR DESCRIPTION
… and response"

This reverts commit 1002fe1330db81cf603f40be4d0d54bb671f9197.

**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.1-apim-8981-revert-change-for-new-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/3.2.1-apim-8981-revert-change-for-new-release-SNAPSHOT/gravitee-policy-transformheaders-3.2.1-apim-8981-revert-change-for-new-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
