### PR TITLE
fix: allow message to be used in EL

### DIFF
--- a/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
@@ -118,17 +118,17 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
 
     @Override
     public Completable onMessageRequest(KafkaMessageExecutionContext ctx) {
-        return ctx.request().onMessage(message -> transformKafkaMessageHeaders(ctx.executionContext(), message));
+        return ctx.request().onMessage(message -> transformKafkaMessageHeaders(ctx, message));
     }
 
     @Override
     public Completable onMessageResponse(KafkaMessageExecutionContext ctx) {
-        return ctx.response().onMessage(message -> transformKafkaMessageHeaders(ctx.executionContext(), message));
+        return ctx.response().onMessage(message -> transformKafkaMessageHeaders(ctx, message));
     }
 
-    private Maybe<KafkaMessage> transformKafkaMessageHeaders(KafkaExecutionContext ctx, KafkaMessage kafkaMessage) {
-        return transformHeaders(ctx.getTemplateEngine(), kafkaMessage)
-            .onErrorResumeWith(ctx.interruptWith(Errors.INVALID_RECORD))
+    private Maybe<KafkaMessage> transformKafkaMessageHeaders(KafkaMessageExecutionContext ctx, KafkaMessage kafkaMessage) {
+        return transformHeaders(ctx.getTemplateEngine(kafkaMessage), kafkaMessage)
+            .onErrorResumeWith(ctx.executionContext().interruptWith(Errors.INVALID_RECORD))
             .andThen(Maybe.just(kafkaMessage));
     }
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

allow message to be used in EL
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.2-fix-allow-message-in-EL-expression-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/4.0.2-fix-allow-message-in-EL-expression-SNAPSHOT/gravitee-policy-transformheaders-4.0.2-fix-allow-message-in-EL-expression-SNAPSHOT.zip)
  <!-- Version placeholder end -->
