### PR TITLE
fix: revert schema-form.json ref part for v2 and v4 to resolve Transform Headers UI issue

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -2,35 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": false,
-    "definitions": {
-        "_header": {
-            "type": "object",
-            "title": "Header",
-            "properties": {
-                "name": {
-                    "title": "Name",
-                    "description": "Name of the header",
-                    "type": "string",
-                    "pattern": "^\\S*$",
-                    "validationMessage": {
-                        "202": "Header name must not contain spaces."
-                    }
-                },
-                "value": {
-                    "title": "Value",
-                    "description": "Value of the header",
-                    "type": "string",
-                    "x-schema-form": {
-                        "expression-language": true
-                    },
-                    "gioConfig": {
-                        "el": true
-                    }
-                }
-            },
-            "required": ["name", "value"]
-        }
-    },
     "properties": {
         "scope": {
             "title": "Scope",
@@ -64,7 +35,28 @@
             "title": "Set/replace headers",
             "description": "Values defined here will replace existing values if a header with the same name is already defined in the request.",
             "items": {
-                "$ref": "#/definitions/_header"
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the header",
+                        "type": "string",
+                        "pattern": "^\\S*$",
+                        "validationMessage": {
+                            "202": "Header name must not contain spaces."
+                        }
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the header",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
             },
             "gioConfig": {
                 "uiType": "gio-headers-array"
@@ -75,7 +67,28 @@
             "title": "Append headers",
             "description": "Similar to set / Replace headers, but the values will be appended instead of being replaced if a header with the same name is already defined in the request. Multiple entries can be used to append several values to the same header name.",
             "items": {
-                "$ref": "#/definitions/_header"
+                "type": "object",
+                "title": "Header",
+                "properties": {
+                    "name": {
+                        "title": "Name",
+                        "description": "Name of the header",
+                        "type": "string",
+                        "pattern": "^\\S*$",
+                        "validationMessage": {
+                            "202": "Header name must not contain spaces."
+                        }
+                    },
+                    "value": {
+                        "title": "Value",
+                        "description": "Value of the header",
+                        "type": "string",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    }
+                },
+                "required": ["name", "value"]
             },
             "gioConfig": {
                 "uiType": "gio-headers-array",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10184

**Description**
Issue -
The Transform Headers policy editor is not functioning correctly in the Console UI for v2 APIs. Specifically:
When attempting to set, replace, or append headers, the UI renders only a single input field, instead of a structured key-value pair.
Modifications made to existing headers cannot be saved.
For already-configured policies, headers show as [object Object], making them unreadable.
These issues are specific to v2 APIs — v4 APIs are not affected.

Root cause -
The policy UI relies on a common schema-form.json for both v2 and v4 APIs. However, the internal schema structure differs slightly between v2 and v4. v2 uses custom object-based headers, which are not properly handled by the current schema definition, leading to malformed rendering in the form.

Fix -
Reverted schema-form changes back to original.
Updated the existing schema-form.json to directly support the v2 and v4 structure (policy studio).
Removed usage of $ref to simplify schema resolution and improve compatibility.
Applied minimal changes needed to fix the v2 rendering and saving issues.


https://github.com/user-attachments/assets/9b9aad41-874d-4295-a59b-9f166e55790b



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.1-APIM-10184-fix-segregated-v2-transform-headers-schema-form-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/4.1.1-APIM-10184-fix-segregated-v2-transform-headers-schema-form-SNAPSHOT/gravitee-policy-transformheaders-4.1.1-APIM-10184-fix-segregated-v2-transform-headers-schema-form-SNAPSHOT.zip)
  <!-- Version placeholder end -->
