### PR TITLE
fix: update gravitee-parent to 22.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.4.1</version>
+        <version>22.5.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10184

**Description**
bump gravitee-parent

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.2-APIM-10184-fix-bump-gravitee-parent-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/4.1.2-APIM-10184-fix-bump-gravitee-parent-SNAPSHOT/gravitee-policy-transformheaders-4.1.2-APIM-10184-fix-bump-gravitee-parent-SNAPSHOT.zip)
  <!-- Version placeholder end -->
