### PR TITLE
feat: include cause throwable in the execution failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.14.2
+    gravitee: gravitee-io/gravitee@5.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -1,7 +1,10 @@
 rows:
     - data:
+          plugin: "5.x"
+          apim: "4.9.x to latest"
+    - data:
           plugin: "4.x"
-          apim: "4.6.x to latest"
+          apim: "4.6.x to 4.8.x"
     - data:
           plugin: "3.x"
           apim: "4.0.x to 4.5.x"

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ Strikethrough text indicates that a version is deprecated.
 
 | Plugin version| APIM |
 | --- | ---  |
-|4.x|4.6.x to latest |
+|5.x|4.9.x to latest |
+|4.x|4.6.x to 4.8.x |
 |3.x|4.0.x to 4.5.x |
 |~~1.x~~|~~3.x~~ |
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-transformheaders</artifactId>
-    <version>4.2.0</version>
+    <version>5.0.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Policy - Transform Headers</name>
     <description>Override HTTP headers of incoming request or outbound response</description>
@@ -34,12 +34,11 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.17</gravitee-apim.version>
+        <gravitee-apim.version>4.9.0-alpha.2-SNAPSHOT</gravitee-apim.version>
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
         <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>5.0.2</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>8.0.0-alpha.2</gravitee-reactor-message.version>
 
-        <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>
 
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
@@ -214,7 +213,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
+++ b/src/main/java/io/gravitee/policy/transformheaders/TransformHeadersPolicy.java
@@ -67,9 +67,12 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
 
     private Completable transform(final HttpPlainExecutionContext ctx, final HttpHeaders httpHeaders) {
         return transformHeaders(ctx.getTemplateEngine(), httpHeaders)
-            .onErrorResumeWith(
+            .onErrorResumeNext(throwable ->
                 ctx.interruptWith(
-                    new ExecutionFailure(500).key(TRANSFORM_HEADERS_FAILURE).message("Unable to apply headers transformation")
+                    new ExecutionFailure(500)
+                        .key(TRANSFORM_HEADERS_FAILURE)
+                        .message("Unable to apply headers transformation")
+                        .cause(throwable)
                 )
             );
     }
@@ -87,9 +90,12 @@ public class TransformHeadersPolicy extends TransformHeadersPolicyV3 implements 
     private Maybe<Message> transformMessageHeaders(final HttpMessageExecutionContext ctx, final Message message) {
         return transformHeaders(ctx.getTemplateEngine(message), message.headers())
             .andThen(Maybe.just(message))
-            .onErrorResumeWith(
+            .onErrorResumeNext(throwable ->
                 ctx.interruptMessageWith(
-                    new ExecutionFailure(500).key(TRANSFORM_HEADERS_FAILURE).message("Unable to apply headers transformation on message")
+                    new ExecutionFailure(500)
+                        .key(TRANSFORM_HEADERS_FAILURE)
+                        .message("Unable to apply headers transformation on message")
+                        .cause(throwable)
                 )
             );
     }

--- a/src/test/resources/apis/add-update-whitelist-remove-headers-v4-message-publish.json
+++ b/src/test/resources/apis/add-update-whitelist-remove-headers-v4-message-publish.json
@@ -71,5 +71,8 @@
                 }
             ]
         }
-    ]
+    ],
+    "analytics": {
+        "enabled": true
+    }
 }

--- a/src/test/resources/apis/add-update-whitelist-remove-headers-v4-message-subscribe.json
+++ b/src/test/resources/apis/add-update-whitelist-remove-headers-v4-message-subscribe.json
@@ -93,5 +93,8 @@
                 }
             ]
         }
-    ]
+    ],
+    "analytics": {
+        "enabled": true
+    }
 }

--- a/src/test/resources/apis/append-headers-v4-message-publish.json
+++ b/src/test/resources/apis/append-headers-v4-message-publish.json
@@ -69,5 +69,8 @@
                 }
             ]
         }
-    ]
+    ],
+    "analytics": {
+        "enabled": true
+    }
 }

--- a/src/test/resources/apis/append-headers-v4-message-subscribe.json
+++ b/src/test/resources/apis/append-headers-v4-message-subscribe.json
@@ -77,5 +77,8 @@
                 }
             ]
         }
-    ]
+    ],
+    "analytics": {
+        "enabled": true
+    }
 }


### PR DESCRIPTION
BREAKING CHANGE: requires APIM version 4.9.0 or later

**Issue**

https://gravitee.atlassian.net/browse/APIM-10086

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-APIM-9992-logs-trace-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.0.0-APIM-9992-logs-trace-SNAPSHOT/gravitee-policy-transformheaders-5.0.0-APIM-9992-logs-trace-SNAPSHOT.zip)
  <!-- Version placeholder end -->
