### PR TITLE
fix: update apim to 4.9.0-alpha.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@5.1.1
+    gravitee: gravitee-io/gravitee@5.4.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.md
+++ b/README.md
@@ -364,6 +364,18 @@ spec:
 
 ## Changelog
 
+### [5.0.0](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/4.2.0...5.0.0) (2025-09-17)
+
+
+##### Features
+
+* include cause throwable in the execution failure ([e5f45da](https://github.com/gravitee-io/gravitee-policy-transformheaders/commit/e5f45da9203a5fc7d9378d2584c07f33a315e5e8))
+
+
+##### BREAKING CHANGES
+
+* requires APIM version 4.9.0 or later
+
 ### [4.2.0](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/4.1.3...4.2.0) (2025-09-16)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.9.0-alpha.2-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.9.0-alpha.2</gravitee-apim.version>
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
         <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
         <gravitee-reactor-message.version>8.0.0-alpha.2</gravitee-reactor-message.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9992

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-update-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.0.1-update-deps-SNAPSHOT/gravitee-policy-transformheaders-5.0.1-update-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
