### PR TITLE
fix: update gravitee-parent to 23.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <properties>
         <gravitee-apim.version>4.9.0-alpha.2</gravitee-apim.version>
         <gravitee-sse.version>5.0.0</gravitee-sse.version>
         <gravitee-http-post.version>2.1.0</gravitee-http-post.version>
-        <gravitee-reactor-message.version>8.0.0-alpha.2</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>8.0.0</gravitee-reactor-message.version>
 
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>
 

--- a/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/TransformHeadersPolicyV4IntegrationTest.java
@@ -93,15 +93,14 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
     @DeployApi("/apis/add-update-whitelist-remove-headers-v4-proxy.json")
     void should_add_update_and_remove_headers_with_proxy_api(HttpClient client) throws InterruptedException {
         wiremock.stubFor(
-            get("/endpoint")
-                .willReturn(
-                    ok()
-                        .withHeader("toupdatekeyresponse", "responseToUpdate")
-                        .withHeader("toremovekeyresponse", "willBeRemoved")
-                        .withHeader("whitelistedkeyresponse", "whitelisted")
-                        .withHeader("notinwhitelistkeyresponse1", "excluded")
-                        .withHeader("notinwhitelistkeyresponse2", "excluded")
-                )
+            get("/endpoint").willReturn(
+                ok()
+                    .withHeader("toupdatekeyresponse", "responseToUpdate")
+                    .withHeader("toremovekeyresponse", "willBeRemoved")
+                    .withHeader("whitelistedkeyresponse", "whitelisted")
+                    .withHeader("notinwhitelistkeyresponse1", "excluded")
+                    .withHeader("notinwhitelistkeyresponse2", "excluded")
+            )
         );
 
         final TestObserver<HttpClientResponse> obs = client
@@ -242,20 +241,17 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
             .filter(buffer -> !buffer.toString().startsWith("retry:") && !buffer.toString().startsWith(":"))
             .test()
             .awaitCount(1)
-            .assertValueAt(
-                0,
-                chunk -> {
-                    final String[] splitMessage = chunk.toString().split("\n");
-                    assertThat(splitMessage).hasSize(6);
-                    assertThat(splitMessage[0]).isEqualTo("id: 0");
-                    assertThat(splitMessage[1]).isEqualTo("event: message");
-                    assertThat(splitMessage[2]).isEqualTo("data: { \"message\": \"hello\" }");
-                    assertThat(splitMessage[3]).isEqualTo(":whitelistedKeyResponse: whitelisted");
-                    assertThat(splitMessage[4]).isEqualTo(":headerKeyResponse: headerValue");
-                    assertThat(splitMessage[5]).isEqualTo(":toUpdateKeyResponse: updatedValue");
-                    return true;
-                }
-            );
+            .assertValueAt(0, chunk -> {
+                final String[] splitMessage = chunk.toString().split("\n");
+                assertThat(splitMessage).hasSize(6);
+                assertThat(splitMessage[0]).isEqualTo("id: 0");
+                assertThat(splitMessage[1]).isEqualTo("event: message");
+                assertThat(splitMessage[2]).isEqualTo("data: { \"message\": \"hello\" }");
+                assertThat(splitMessage[3]).isEqualTo(":whitelistedKeyResponse: whitelisted");
+                assertThat(splitMessage[4]).isEqualTo(":headerKeyResponse: headerValue");
+                assertThat(splitMessage[5]).isEqualTo(":toUpdateKeyResponse: updatedValue");
+                return true;
+            });
     }
 
     @Test
@@ -274,17 +270,14 @@ class TransformHeadersPolicyV4IntegrationTest extends AbstractPolicyTest<Transfo
             .filter(buffer -> !buffer.toString().startsWith("retry:") && !buffer.toString().startsWith(":"))
             .test()
             .awaitCount(1)
-            .assertValueAt(
-                0,
-                chunk -> {
-                    final String[] splitMessage = chunk.toString().split("\n");
-                    assertThat(splitMessage).hasSize(4);
-                    assertThat(splitMessage[0]).isEqualTo("id: 0");
-                    assertThat(splitMessage[1]).isEqualTo("event: message");
-                    assertThat(splitMessage[2]).isEqualTo("data: { \"message\": \"hello\" }");
-                    assertThat(splitMessage[3]).isEqualTo(":headerKeyResponse: headerValue0,headerValue1,headerValue2");
-                    return true;
-                }
-            );
+            .assertValueAt(0, chunk -> {
+                final String[] splitMessage = chunk.toString().split("\n");
+                assertThat(splitMessage).hasSize(4);
+                assertThat(splitMessage[0]).isEqualTo("id: 0");
+                assertThat(splitMessage[1]).isEqualTo("event: message");
+                assertThat(splitMessage[2]).isEqualTo("data: { \"message\": \"hello\" }");
+                assertThat(splitMessage[3]).isEqualTo(":headerKeyResponse: headerValue0,headerValue1,headerValue2");
+                return true;
+            });
     }
 }

--- a/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3IntegrationTest.java
@@ -42,15 +42,14 @@ class TransformHeadersPolicyV3IntegrationTest extends AbstractPolicyTest<Transfo
     @DisplayName("Should add, update, whitelist and remove headers")
     void shouldAddUpdateAndRemoveHeaders(HttpClient client) throws InterruptedException {
         wiremock.stubFor(
-            get("/endpoint")
-                .willReturn(
-                    ok()
-                        .withHeader("toupdatekeyresponse", "responseToUpdate")
-                        .withHeader("toremovekeyresponse", "willBeRemoved")
-                        .withHeader("whitelistedkeyresponse", "whitelisted")
-                        .withHeader("notinwhitelistkeyresponse1", "excluded")
-                        .withHeader("notinwhitelistkeyresponse2", "excluded")
-                )
+            get("/endpoint").willReturn(
+                ok()
+                    .withHeader("toupdatekeyresponse", "responseToUpdate")
+                    .withHeader("toremovekeyresponse", "willBeRemoved")
+                    .withHeader("whitelistedkeyresponse", "whitelisted")
+                    .withHeader("notinwhitelistkeyresponse1", "excluded")
+                    .withHeader("notinwhitelistkeyresponse2", "excluded")
+            )
         );
 
         final TestObserver<HttpClientResponse> obs = client

--- a/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/transformheaders/v3/TransformHeadersPolicyV3Test.java
@@ -122,8 +122,9 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnRequest_addHeader() {
         // Prepare
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value"))
+        );
 
         // Run
         transformHeadersPolicy.onRequest(request, response, executionContext, policyChain);
@@ -138,8 +139,9 @@ public class TransformHeadersPolicyV3Test {
         // Prepare
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
         when(transformHeadersPolicyConfiguration.getRemoveHeaders()).thenReturn(null);
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value"))
+        );
 
         // Run
         transformHeadersPolicy.onResponse(request, response, executionContext, policyChain);
@@ -153,8 +155,9 @@ public class TransformHeadersPolicyV3Test {
     void test_OnResponse_addMultipleHeaders() {
         // Prepare
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Arrays.asList(new HttpHeader("X-Gravitee-Header1", "Header1"), new HttpHeader("X-Gravitee-Header2", "Header2")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Arrays.asList(new HttpHeader("X-Gravitee-Header1", "Header1"), new HttpHeader("X-Gravitee-Header2", "Header2"))
+        );
 
         // Run
         transformHeadersPolicy.onResponse(request, response, executionContext, policyChain);
@@ -168,8 +171,9 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnRequest_addHeader_nullValue() {
         // Prepare
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", null)));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", null))
+        );
 
         // Run
         transformHeadersPolicy.onRequest(request, response, executionContext, policyChain);
@@ -183,8 +187,9 @@ public class TransformHeadersPolicyV3Test {
     void test_OnResponse_addHeader_nullValue() {
         // Prepare
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", null)));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", null))
+        );
 
         // Run
         transformHeadersPolicy.onResponse(request, response, executionContext, policyChain);
@@ -225,8 +230,9 @@ public class TransformHeadersPolicyV3Test {
     void test_OnRequest_updateHeader() {
         // Prepare
         requestHttpHeaders.set("X-Gravitee-Test", "Initial");
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value"))
+        );
 
         // Run
         transformHeadersPolicy.onRequest(request, response, executionContext, policyChain);
@@ -241,8 +247,9 @@ public class TransformHeadersPolicyV3Test {
         // Prepare
         responseHttpHeaders.set("X-Gravitee-Test", "Initial");
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE);
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Gravitee-Test", "Value"))
+        );
 
         // Run
         transformHeadersPolicy.onResponse(request, response, executionContext, policyChain);
@@ -384,8 +391,9 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnRequestContent_addHeader() {
         // Prepare
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Product-Id", "{#jsonPath(#request.content, '$.product.id')}")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Product-Id", "{#jsonPath(#request.content, '$.product.id')}"))
+        );
 
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.REQUEST_CONTENT);
         when(executionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());
@@ -404,8 +412,9 @@ public class TransformHeadersPolicyV3Test {
     @Test
     void test_OnResponseContent_addHeader() {
         // Prepare
-        when(transformHeadersPolicyConfiguration.getAddHeaders())
-            .thenReturn(Collections.singletonList(new HttpHeader("X-Product-Id", "{#jsonPath(#response.content, '$.product.id')}")));
+        when(transformHeadersPolicyConfiguration.getAddHeaders()).thenReturn(
+            Collections.singletonList(new HttpHeader("X-Product-Id", "{#jsonPath(#response.content, '$.product.id')}"))
+        );
 
         when(transformHeadersPolicyConfiguration.getScope()).thenReturn(PolicyScope.RESPONSE_CONTENT);
         when(executionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9992

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.2-APIM-9992-handle-exception-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.0.2-APIM-9992-handle-exception-SNAPSHOT/gravitee-policy-transformheaders-5.0.2-APIM-9992-handle-exception-SNAPSHOT.zip)
  <!-- Version placeholder end -->
