### PR TITLE
feat: enable for MCP & LLM Proxy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,14 @@ The `transform-headers` policy can be applied to the following API types and flo
 * `PROXY`
 * `MESSAGE`
 * `NATIVE KAFKA`
+* `MCP PROXY`
 
 ### Supported flow phases:
 
-* Publish
-* Subscribe
 * Request
 * Response
+* Publish
+* Subscribe
 
 ## Compatibility matrix
 Strikethrough text indicates that a version is deprecated.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The `transform-headers` policy can be applied to the following API types and flo
 * `MESSAGE`
 * `NATIVE KAFKA`
 * `MCP PROXY`
+* `LLM PROXY`
 
 ### Supported flow phases:
 

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -13,4 +13,5 @@ schema=schema-form.json
 http_proxy=REQUEST,RESPONSE
 http_message=REQUEST,RESPONSE,PUBLISH,SUBSCRIBE
 mcp_proxy=REQUEST,RESPONSE
+llm_proxy=REQUEST,RESPONSE
 native_kafka=PUBLISH,SUBSCRIBE

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,9 +6,11 @@ class=io.gravitee.policy.transformheaders.TransformHeadersPolicy
 type=policy
 category=transformation
 icon=transform-headers.svg
+
 documentation=POLICY_STUDIO_DOC.md
 schema=schema-form.json
-proxy=REQUEST,RESPONSE
-message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
 
+http_proxy=REQUEST,RESPONSE
+http_message=REQUEST,RESPONSE,PUBLISH,SUBSCRIBE
+mcp_proxy=REQUEST,RESPONSE
 native_kafka=PUBLISH,SUBSCRIBE


### PR DESCRIPTION
**Issue**
https://gravitee.atlassian.net/browse/APIM-11427
https://gravitee.atlassian.net/browse/APIM-11782

**Description**

Make this policy compatible with MCP & LLM PROXY API

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-APIM-11427-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.1.0-APIM-11427-SNAPSHOT/gravitee-policy-transformheaders-5.1.0-APIM-11427-SNAPSHOT.zip)
  <!-- Version placeholder end -->
