### PR TITLE
Merge alpha in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [5.1.0-alpha.1](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/5.0.2...5.1.0-alpha.1) (2025-11-07)
+
+
+### Features
+
+* enable for LLM Proxy API ([3aff219](https://github.com/gravitee-io/gravitee-policy-transformheaders/commit/3aff219b946c00f386dc286c880157b5a5e0fce9))
+* enable for MCP Proxy API ([86a0c48](https://github.com/gravitee-io/gravitee-policy-transformheaders/commit/86a0c48c38aff888873d23559398c731fff8933b))
+
 ## [5.0.2](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/5.0.1...5.0.2) (2025-09-19)
 
 

--- a/README.md
+++ b/README.md
@@ -169,13 +169,14 @@ The `transform-headers` policy can be applied to the following API types and flo
 * `PROXY`
 * `MESSAGE`
 * `NATIVE KAFKA`
+* `MCP PROXY`
 
 ### Supported flow phases:
 
-* Publish
-* Subscribe
 * Request
 * Response
+* Publish
+* Subscribe
 
 ## Compatibility matrix
 Strikethrough text indicates that a version is deprecated.

--- a/README.md
+++ b/README.md
@@ -366,6 +366,14 @@ spec:
 
 ## Changelog
 
+### [5.1.0-alpha.1](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/5.0.2...5.1.0-alpha.1) (2025-11-07)
+
+
+##### Features
+
+* enable for LLM Proxy API ([3aff219](https://github.com/gravitee-io/gravitee-policy-transformheaders/commit/3aff219b946c00f386dc286c880157b5a5e0fce9))
+* enable for MCP Proxy API ([86a0c48](https://github.com/gravitee-io/gravitee-policy-transformheaders/commit/86a0c48c38aff888873d23559398c731fff8933b))
+
 #### [5.0.2](https://github.com/gravitee-io/gravitee-policy-transformheaders/compare/5.0.1...5.0.2) (2025-09-19)
 
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The `transform-headers` policy can be applied to the following API types and flo
 * `MESSAGE`
 * `NATIVE KAFKA`
 * `MCP PROXY`
+* `LLM PROXY`
 
 ### Supported flow phases:
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-transformheaders</artifactId>
-    <version>5.0.2</version>
+    <version>5.1.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Policy - Transform Headers</name>
     <description>Override HTTP headers of incoming request or outbound response</description>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -13,4 +13,5 @@ schema=schema-form.json
 http_proxy=REQUEST,RESPONSE
 http_message=REQUEST,RESPONSE,PUBLISH,SUBSCRIBE
 mcp_proxy=REQUEST,RESPONSE
+llm_proxy=REQUEST,RESPONSE
 native_kafka=PUBLISH,SUBSCRIBE

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,9 +6,11 @@ class=io.gravitee.policy.transformheaders.TransformHeadersPolicy
 type=policy
 category=transformation
 icon=transform-headers.svg
+
 documentation=POLICY_STUDIO_DOC.md
 schema=schema-form.json
-proxy=REQUEST,RESPONSE
-message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
 
+http_proxy=REQUEST,RESPONSE
+http_message=REQUEST,RESPONSE,PUBLISH,SUBSCRIBE
+mcp_proxy=REQUEST,RESPONSE
 native_kafka=PUBLISH,SUBSCRIBE


### PR DESCRIPTION
**Description**

Merge alpha in master
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-merge-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.1.0-merge-alpha-SNAPSHOT/gravitee-policy-transformheaders-5.1.0-merge-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
