### PR TITLE
fix(ci): Updating the orb and added provided scope to deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@5.4.0
+    gravitee: gravitee-io/gravitee@5.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
** Issue **

https://gravitee.atlassian.net/browse/APIM-13243

** Description **

Bumping up the gravitee-bom version.
Fix for vulnerability GHSA 72hv-8253 57qq

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.2.1-fix-apim-13243-main-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-transformheaders/5.2.1-fix-apim-13243-main-SNAPSHOT/gravitee-policy-transformheaders-5.2.1-fix-apim-13243-main-SNAPSHOT.zip)
  <!-- Version placeholder end -->
